### PR TITLE
Introduce default settings.

### DIFF
--- a/includes/classes/Settings.php
+++ b/includes/classes/Settings.php
@@ -15,14 +15,17 @@ namespace AdminNoticesManager;
  */
 class Settings {
 
-	public static $option_name = 'anm_settings';
+	/**
+	 * @var string Name of the option storing the plugin settings.
+	 */
+	private static $option_name = 'anm_settings';
 
 	/**
 	 * Settings constructor.
 	 */
 	public function __construct() {
 
-		$options = get_option( self::$option_name, array() );
+		$options = self::get_settings();
 
 		if ( ! class_exists( 'RationalOptionPages' ) ) {
 			require_once( ADMIN_NOTICES_MANAGER_INC . 'vendor' . DIRECTORY_SEPARATOR . 'jeremyHixon-RationalOptionPages' . DIRECTORY_SEPARATOR . 'RationalOptionPages.php' );
@@ -95,5 +98,16 @@ class Settings {
 		);
 
 		new \RationalOptionPages( $pages );
+	}
+
+	public static function get_settings() {
+		return wp_parse_args( get_option( self::$option_name, array() ), [
+			"success_level_notices"          => "popup-only",
+			"error_level_notices"            => "popup-only",
+			"warning_level_notices"          => "popup-only",
+			"information_level_notices"      => "popup-only",
+			"no_level_notices"               => "popup-only",
+			"wordpress_system_admin_notices" => "leave"
+		] );
 	}
 }

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -263,7 +263,7 @@ function admin_scripts() {
 		'title'           => esc_html__( 'Admin notices', 'admin-notices-manager' ),
 		'title_empty'     => esc_html__( 'No admin notices', 'admin-notices-manager' ),
 		'system_messages' => $system_messages,
-		'settings'        => get_option( Settings::$option_name )
+		'settings'        => Settings::get_settings()
 	] );
 
 }


### PR DESCRIPTION
Fix for issue https://github.com/WPWhiteSecurity/admin-notices-manager/issues/28. I introduced a single central function for loading the settings. It contains defaults.