### PR TITLE
Don't allow notice hiding on WP Mail SMTP admin pages.

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -55,7 +55,13 @@ function init() {
 			\S24WP::init( ADMIN_NOTICES_MANAGER_URL . 'vendor/wpwhitesecurity/select2-wpwhitesecurity' );
 		}
 
+		// Check if the notices can be hidden for the currently logged-in user.
 		$notice_hiding_allowed = Settings::notice_hiding_allowed_for_current_user();
+		// Don't allow notice hiding on WP Mail SMTP admin pages.
+		if ( $notice_hiding_allowed && function_exists( 'wp_mail_smtp' ) && wp_mail_smtp()->get_admin()->is_admin_page() ) {
+			$notice_hiding_allowed = false;
+		}
+
 		new Notices( $notice_hiding_allowed );
 		new Pointer();
 		new Settings();


### PR DESCRIPTION
Fixes https://github.com/wpwhitesecurity/admin-notices-manager/issues/63.

We don't attempt to hide notices on admin pages belonging to the WP Mail SMTP plugin.